### PR TITLE
Switch heredoc operator to <--<

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -1161,3 +1161,93 @@ Successfully fulfilled user requirements: "make sure all of the operators are ea
 
 **Build Status Note:**
 Implementation complete and tested. Help system implemented but requires rebuild for full functionality. All mathematical enhancements verified working. Source code modifications preserve existing functionality while adding requested features.
+
+### [2025-12-12] Readline – Username completion compatibility
+
+**Discovery:** Modern readline requires `rl_username_completion_function`
+
+**Details:** Added an explicit prototype for `rl_username_completion_function` and updated the built-in completion logic to call the new symbol when expanding tilde-prefixed usernames. This resolves build failures against recent readline releases where the legacy `username_completion_function` prototype is hidden.【F:input.c†L30-L34】【F:input.c†L544-L565】
+
+### [2025-12-12] Build System – Math library linkage
+
+**Discovery:** Math primitives needed explicit `-lm`
+
+**Details:** Linking now pulls in libm to satisfy `fmod` and `pow` from the arithmetic primitives. The Makefile template includes `-lm`, ensuring both `es` and `esdump` link successfully on platforms that keep math functions in a separate library.【F:Makefile.in†L48-L59】【F:Makefile†L45-L55】
+
+### [2025-12-12] Parser – Function definitions no longer treated as variable lookups
+
+**Discovery:** Removed aggressive word-to-variable rewriting
+
+**Details:** The grammar no longer wraps every parsed word in `nVar`, which previously caused `fn` definitions like `fn var { ... }` to expand to empty names and abort esdump with "null variable name." Word parsing now preserves literal names, while infix normalization still converts arithmetic operands as needed.【F:parse.y†L101-L120】
+
+### [2025-12-12] Formatting – `%g` support for numeric primitives
+
+**Discovery:** Added floating-point formatting hook
+
+**Details:** Introduced a `%g` formatter using `snprintf` so `str("%g", ...)` in math primitives no longer triggers `printfmt` panics. The formatting table now recognizes `%g`, allowing arithmetic primitives to emit floating-point results safely and keeping the test suite green.【F:print.c†L3-L7】【F:print.c†L154-L169】【F:print.c†L186-L201】
+
+### [2025-12-12] Build & Runtime – Full rebuild and smoke test
+
+**Discovery:** Verified `build.sh` end-to-end build and runtime
+
+**Details:** Ran `./build.sh --output-dir bin` on Linux, which regenerated `configure`, configured the project, rebuilt from a clean tree, and executed the entire `make test` suite—all passing. The script placed the resulting binary at `bin/es-shell`, and a direct invocation `./bin/es-shell -c 'echo build_run_ok'` produced the expected output, confirming the binary runs after the latest changes.【bf3d48†L1-L53】【178c26†L1-L3】
+
+### [2025-12-12] Formatting – Safe initialization before `printfmt`
+
+**Discovery:** Guard `printfmt` against uninitialized conversion tables
+
+**Details:** `printfmt` now checks whether the conversion table pointer itself is `NULL` before dereferencing it, ensuring format initialization happens even if no prior `fmtinstall` call occurred. This removes a potential null dereference during early print calls while preserving the existing table setup path.【F:print.c†L186-L257】
+
+### [2025-12-12] Process Control – `apids` reports background jobs in pid order
+
+**Discovery:** Sorted `%apids` output numerically
+
+**Details:** The `$&apids` primitive now collects background process IDs, sorts them with a numeric comparator, and constructs the result list from the ascending array. This removes the previous reliance on insertion order and delivers `%apids` results that are stable and monotonic regardless of background creation sequence.【F:proc.c†L68-L94】【F:proc.c†L160-L186】
+
+### [2025-12-13] Process Control – `wait` rejects non-numeric pids
+
+**Discovery:** Validates `$&wait` arguments are numeric process IDs
+
+**Details:** `$&wait` now parses its optional PID argument with `strtol`, rejecting empty strings, mixed text, and oversized values instead of silently interpreting them as zero. Invalid input raises the existing “bad pid” error with the original token preserved, and a new regression test covers the non-numeric case.【F:proc.c†L96-L123】【F:test/tests/wait.es†L44-L53】
+
+### [2025-12-13] Subscripts – reject malformed indices
+
+**Discovery:** Validate list subscripts before slicing
+
+**Details:** Subscript parsing now treats any non-numeric or overflowed index as a “bad subscript” error instead of truncating trailing text to zero. Both single-value and range selectors call a helper that checks for empty strings, extra characters, or values beyond `INT_MAX`, and new regression tests confirm `$foo(2abc)` and `$foo(1...3abc)` raise the expected errors.【F:glom.c†L103-L164】【F:test/tests/subscript.es†L1-L16】
+
+### [2025-12-13] Subscripts – disallow descending ranges
+
+**Discovery:** Prevent silently empty slice selection when range upper bounds precede the start index
+
+**Details:** Subscript ranges such as `$foo(3...2)` now raise a “bad subscript” error instead of producing no output. The glom logic validates that the parsed high index is at least the low index before applying bounds clamping, and a regression test asserts the descending case errors with the full `low...high` token preserved.【F:glom.c†L137-L166】【F:test/tests/subscript.es†L18-L25】
+
+### [2025-12-13] Math – enforce strict integer parsing
+
+**Discovery:** Bitwise and integer-only math primitives validate integer tokens
+
+**Details:** Added a shared `try_parse_long` helper that rejects empty strings, trailing characters, and `strtol` overflows. Bitwise shift, and/or/xor/not, and integer arithmetic primitives now fail with a message that includes the offending token, and `%isint` uses the same strict parser so empty or alphabetic inputs are no longer treated as integers. Regression tests cover invalid bitwise operands and `isint` behavior.【F:prim-math.c†L3-L112】【F:prim-math.c†L200-L361】【F:prim-math.c†L447-L606】【F:test/tests/math.es†L30-L49】
+
+### [2025-12-13] Math – reject overflowing float arguments
+
+**Discovery:** Treat floating-point overflow as invalid input
+
+**Details:** Introduced a `require_double` helper that uses `strtod` with `ERANGE` detection and applies it across arithmetic, comparison, and conversion primitives so tokens that overflow `double` now raise the existing numeric error instead of turning into infinities. `%isfloat` treats overflowing inputs as false, new regression tests exercise the `1e309` overflow paths, and an interactive `%addition 1e309` run now emits “arguments must be numbers” instead of returning `inf`.【F:prim-math.c†L6-L193】【F:prim-math.c†L330-L437】【F:test/tests/math.es†L51-L63】【fc9fb1†L1-L3】
+
+### [2025-12-13] Syntax – regression suite coverage and heredoc newline quirk
+
+**Discovery:** Syntax sugar, precedence, and lexer cases all pass, but heredoc sugar expects a trailing newline
+
+**Details:** Running `./build.sh --output-dir bin` executes `./test/test.es ./test/tests/*`, and the syntax suite confirms the parser rewrites control-flow, redirection, heredoc, match, and precedence sugar correctly alongside lexical and tokenizer checks; every syntax case reported “passed.”【F:test/tests/syntax.es†L13-L67】【c33a41†L46-L52】 Direct evaluation shows heredoc sugar emits the expected `%here` form when the closing tag ends with a newline, but parsing without the final newline raises “incomplete here document,” indicating the sugar requires that trailing line break.【1cf0ec†L1-L5】【ffcf93†L1-L4】
+
+### [2025-12-13] Syntax – heredoc sugar tolerates missing trailing newline
+
+**Discovery:** Heredoc sugar now accepts EOF markers without a following newline
+
+**Details:** `snarfheredoc` treats the heredoc terminator as complete when the marker is followed by any non-word delimiter (such as `}`) instead of insisting on a newline, ungetting the delimiter so subsequent parsing proceeds normally. This prevents “incomplete here document” errors when the closing tag appears immediately before other syntax. The syntax regression suite now includes a heredoc sugar example that omits the final newline yet still rewrites to the same `%here` form.【F:heredoc.c†L55-L70】【F:test/tests/syntax.es†L9-L17】
+
+### [2025-12-14] Syntax – heredoc operator renamed to `<--<`
+
+**Discovery:** Here documents now use the `<--<` redirection operator instead of `<<`
+
+**Details:** The lexer recognizes `<--<` as the heredoc operator, queues heredocs as before, and emits a clear scan-time error when the legacy `<<` form appears. The man page, examples, and heredoc sugar regression were updated to use the new spelling, and a regression test asserts the old operator reports the explanatory error.【F:token.c†L351-L383】【F:doc/es.1†L1068-L1084】【F:examples/adventure.es†L43-L47】【F:test/tests/trip.es†L216-L229】【F:test/tests/syntax.es†L67-L75】

--- a/Makefile.in
+++ b/Makefile.in
@@ -47,7 +47,7 @@ MKDIR_P         = @MKDIR_P@
 
 CFLAGS          = @STRICT_CFLAGS@ -I. -I$(srcdir) -W -Wall @READLINE_CFLAGS@ @CFLAGS@ $(ADDCFLAGS)
 LDFLAGS         = @LDFLAGS@ $(ADDLDFLAGS)
-LIBS            = @READLINE_LIBS@ @LIBS@ $(ADDLIBS)
+LIBS            = @READLINE_LIBS@ @LIBS@ $(ADDLIBS) -lm
 
 HFILES          = config.h es.h gc.h input.h prim.h print.h sigmsgs.h \
                   stdenv.h syntax.h term.h var.h

--- a/doc/es.1
+++ b/doc/es.1
@@ -1068,7 +1068,7 @@ these operators use file descriptor 1 by default.
 .IR sh (1)
 with the use of
 .Ds
-.Ic command " << \(aq" eof-marker "\(aq"
+.Ic command " <--< \(aq" eof-marker "\(aq"
 .De
 .PP
 If the end-of-file marker is quoted,
@@ -1845,7 +1845,7 @@ fn \fIname\fP \fIargs\fP { \fIcmd\fP }	fn-\(ha\fIname\fP = @ \fIargs\fP {\fIcmd\
 \fIcmd\fP >>< \fIfile\fP	%open-append 1 \fIfile\fP {\fIcmd\fP}
 \fIcmd\fP >[\fIn\fP=]	%close \fIn\fP {\fIcmd\fP}
 \fIcmd\fP >[\fIm\fP=\fIn\fP]	%dup \fIm\fP \fIn\fP {\fIcmd\fP}
-\fIcmd\fP << tag \fIinput\fP tag	%here 0 \fIinput\fP {\fIcmd\fP}
+\fIcmd\fP <--< tag \fIinput\fP tag	%here 0 \fIinput\fP {\fIcmd\fP}
 \fIcmd\fP <<< \fIstring\fP	%here 0 \fIstring\fP {\fIcmd\fP}
 \fIcmd1\fP | \fIcmd2\fP	%pipe {\fIcmd1\fP} 1 0 {\fIcmd2\fP}
 \fIcmd1\fP |[\fIm\fP=\fIn\fP] \fIcmd2\fP	%pipe {\fIcmd1\fP} \fIm\fP \fIn\fP {\fIcmd2\fP}

--- a/examples/adventure.es
+++ b/examples/adventure.es
@@ -42,7 +42,7 @@ if {~ $#PAGER 0} {
 }
 
 fn instructions {
-  cat << EOF
+  cat <--< EOF
 
                   Instructions for the Adventure shell
 

--- a/examples/nullcmd.es
+++ b/examples/nullcmd.es
@@ -46,7 +46,7 @@ fn exec cmd {
 
 
 # %here doesn't use %openfile, so we override it as well so that we can do neat
-# things like `> file << EOF`.
+# things like `> file <--< EOF`.
 
 let (h = $fn-%here)
 fn %here fd str cmd {

--- a/glom.c
+++ b/glom.c
@@ -3,6 +3,8 @@
 #include "es.h"
 #include "gc.h"
 
+#include <limits.h>
+
 /* concat -- cartesian cross product concatenation
  * Combines two lists by concatenating every element from list1 with every element from list2
  * Example: list1=[a,b], list2=[1,2] -> result=[a1,a2,b1,b2]
@@ -101,6 +103,16 @@ static List *qconcat(List *first_list, List *second_list, StrList *quote_list1, 
     RefReturn(list);
 }
 
+static int parse_positive_subscript(const char *string) {
+    char *end;
+    long parsed = strtol(string, &end, 10);
+
+    if (*string == '\0' || *end != '\0' || parsed <= 0 || parsed > INT_MAX)
+        return -1;
+
+    return (int) parsed;
+}
+
 /* subscript -- variable subscripting with range support
  * Supports syntax like: $var(1), $var(2...5), $var(1...)
  */
@@ -128,42 +140,47 @@ static List *subscript(List *list, List *subscript_list)
     }
 
     while (subscript_list != NULL)
-    {   low_index = atoi(getstr(subscript_list->term));
-        if (low_index < 1)
-        {   Ref(char *, bad_subscript, getstr(subscript_list->term));
-            gcenable();
-            fail("es:subscript", "bad subscript: %s", bad_subscript);
-            RefEnd(bad_subscript);
+    {   Ref(char *, low_value, getstr(subscript_list->term));
+
+        if ((low_index = parse_positive_subscript(low_value)) < 1)
+        {   gcenable();
+            fail("es:subscript", "bad subscript: %s", low_value);
         }
         subscript_list = subscript_list->next;
-        
+
         if (subscript_list != NULL && streq(getstr(subscript_list->term), "..."))
         {
         mid_range:
             subscript_list = subscript_list->next;
-			
+
             if (subscript_list == NULL)
                 high_index = list_length;
-				
+
             else
-            {   high_index = atoi(getstr(subscript_list->term));
-                if (high_index < 1)
-                {   Ref(char *, bad_subscript, getstr(subscript_list->term));
-                    gcenable();
-	
-                    fail("es:subscript", "bad subscript: %s", bad_subscript);
-                    RefEnd(bad_subscript);
+            {   Ref(char *, high_value, getstr(subscript_list->term));
+                if ((high_index = parse_positive_subscript(high_value)) < 1)
+                {   gcenable();
+                    fail("es:subscript", "bad subscript: %s", high_value);
                 }
-				 
+
+                if (high_index < low_index)
+                {   gcenable();
+                    fail("es:subscript", "bad subscript: %s...%s", low_value, high_value);
+                }
+
                 if (high_index > list_length)
                     high_index = list_length;
-				 
+
                 subscript_list = subscript_list->next;
+
+                RefEnd(high_value);
             }
         }
-			
+
         else
             high_index = low_index;
+
+        RefEnd(low_value);
             
         if (low_index > list_length)
             continue;

--- a/heredoc.c
+++ b/heredoc.c
@@ -50,7 +50,9 @@ extern Tree *snarfheredoc(const char *eof, Boolean quoted) {
 		print_prompt2();
 		for (s = (unsigned char *) eof; (c = GETC()) == *s; s++)
 			;
-		if (*s == '\0' && (c == '\n' || c == EOF)) {
+                if (*s == '\0' && (c == '\n' || c == EOF || (c >= 0 && dnw[c]))) {
+                        if (c != '\n' && c != EOF)
+                                UNGETC(c);
 			if (buf->current == 0 && tree != NULL)
 				freebuffer(buf);
 			else

--- a/initial.es
+++ b/initial.es
@@ -324,6 +324,10 @@ fn-%pow                = $&pow
 fn-%abs                = $&abs
 fn-%min                = $&min
 fn-%max                = $&max
+fn-%toint              = $&toint
+fn-%tofloat            = $&tofloat
+fn-%isint              = $&isint
+fn-%isfloat            = $&isfloat
 fn-%greater            = $&greater
 fn-%less               = $&less
 fn-%greaterequal       = $&greaterequal
@@ -455,7 +459,7 @@ fn %one {
 #    Here documents and here strings are internally rewritten to the
 #    same form, the %here hook function.
 #
-#        cmd << tag input tag    %here 0 input  {cmd}
+#        cmd <--< tag input tag  %here 0 input  {cmd}
 #        cmd <<< string          %here 0 string {cmd}
 
 fn-%here    = $&here

--- a/input.c
+++ b/input.c
@@ -29,6 +29,8 @@ Boolean resetterminal = FALSE;
 
 #if HAVE_READLINE
 #include <readline/readline.h>
+/* Ensure prototype is available even when compat declarations are disabled */
+extern char *rl_username_completion_function(const char *, int);
 #endif
 
 
@@ -557,8 +559,8 @@ char **builtin_completion(const char *text, int UNUSED start, int UNUSED end) {
 	}
 
 	/* ~foo => username.  ~foo/bar already gets completed as filename. */
-	if (!matches && *text == '~' && !strchr(text, '/'))
-		matches = rl_completion_matches(text, username_completion_function);
+        if (!matches && *text == '~' && !strchr(text, '/'))
+                matches = rl_completion_matches(text, rl_username_completion_function);
 
 	return matches;
 }

--- a/parse.y
+++ b/parse.y
@@ -5,16 +5,6 @@
 #include "es.h"
 #include "input.h"
 #include "syntax.h"
-
-static Tree *arithword(Tree *t) {
-       if (t != NULL && t->kind == nWord) {
-               char *end;
-               strtol(t->u[0].s, &end, 10);
-               if (*end != '\0')
-                       return mk(nVar, t);
-       }
-       return t;
-}
 %}
 
 %token <str>	WORD QWORD
@@ -117,7 +107,7 @@ first	: comword			{ $$ = $1; }
 sword	: comword			{ $$ = $1; }
 	| keyword			{ $$ = mk(nWord, $1); }
 
-word    : sword                         { $$ = arithword($1); }
+word    : sword                         { $$ = $1; }
         | word '^' sword                { $$ = mk(nConcat, $1, $3); }
 
 comword : param				{ $$ = $1; }

--- a/prim-math.c
+++ b/prim-math.c
@@ -3,10 +3,47 @@
 #include "es.h"
 #include "prim.h"
 
+#include <errno.h>
 #include <limits.h>
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
+
+static Boolean try_parse_long(const char *string, long *result) {
+    char *end;
+    long parsed;
+
+    errno = 0;
+    parsed = strtol(string, &end, 0);
+
+    if (*string == '\0' || end == string || *end != '\0' || errno == ERANGE)
+        return FALSE;
+
+    *result = parsed;
+    return TRUE;
+}
+
+static double require_double(const char *string, const char *primitive, const char *context) {
+    char *end;
+    double parsed;
+
+    errno = 0;
+    parsed = strtod(string, &end);
+
+    if (*string == '\0' || end == string || *end != '\0' || errno == ERANGE)
+        fail(primitive, "%s", context);
+
+    return parsed;
+}
+
+static long require_integer(const char *string, const char *primitive, const char *context) {
+    long parsed;
+
+    if (!try_parse_long(string, &parsed))
+        fail(primitive, "%s must be an integer: %s", context, string);
+
+    return parsed;
+}
 
 /*
  * Arithmetic Operations
@@ -15,12 +52,8 @@
 PRIM(addition)
 {   double result = 0.0;
 
-    for (List *lp = list; lp != NULL; lp = lp->next)
-    {   char *endptr;
-        double operand = strtod(getstr(lp->term), &endptr);
-
-        if (endptr != NULL && *endptr != '\0')
-            fail("$&addition", "arguments must be numbers");
+    for (List *lp = list; lp != NULL; lp = lp->next) {
+        double operand = require_double(getstr(lp->term), "$&addition", "arguments must be numbers");
 
         result += operand;
     }
@@ -28,22 +61,15 @@ PRIM(addition)
 }
 
 PRIM(subtraction)
-{   char *endptr;
-    double result;
+{   double result;
 
     if (list == NULL || list->next == NULL)
         fail("$&subtraction", "usage: $&subtraction number number [...]");
 
-    result = strtod(getstr(list->term), &endptr);
+    result = require_double(getstr(list->term), "$&subtraction", "arguments must be numbers");
 
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&subtraction", "arguments must be numbers");
-
-    for (list = list->next; list != NULL; list = list->next)
-    {   double operand = strtod(getstr(list->term), &endptr);
-
-        if (endptr != NULL && *endptr != '\0')
-            fail("$&subtraction", "arguments must be numbers");
+    for (list = list->next; list != NULL; list = list->next) {
+        double operand = require_double(getstr(list->term), "$&subtraction", "arguments must be numbers");
 
         result -= operand;
     }
@@ -51,17 +77,13 @@ PRIM(subtraction)
 }
 
 PRIM(multiplication)
-{   char *endptr;
-    double result = 1.0;
+{   double result = 1.0;
 
     if (list == NULL)
         fail("$&multiplication", "usage: $&multiplication number [...]");
 
-    for (List *lp = list; lp != NULL; lp = lp->next)
-    {   double operand = strtod(getstr(lp->term), &endptr);
-
-        if (endptr != NULL && *endptr != '\0')
-            fail("$&multiplication", "arguments must be numbers");
+    for (List *lp = list; lp != NULL; lp = lp->next) {
+        double operand = require_double(getstr(lp->term), "$&multiplication", "arguments must be numbers");
 
         result *= operand;
     }
@@ -69,22 +91,15 @@ PRIM(multiplication)
 }
 
 PRIM(division)
-{   char *endptr;
-    double result;
+{   double result;
 
     if (list == NULL || list->next == NULL)
         fail("$&division", "usage: $&division dividend divisor [...]");
 
-    result = strtod(getstr(list->term), &endptr);
+    result = require_double(getstr(list->term), "$&division", "arguments must be numbers");
 
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&division", "arguments must be numbers");
-
-    for (list = list->next; list != NULL; list = list->next)
-    {   double divisor = strtod(getstr(list->term), &endptr);
-
-        if (endptr != NULL && *endptr != '\0')
-            fail("$&division", "arguments must be numbers");
+    for (list = list->next; list != NULL; list = list->next) {
+        double divisor = require_double(getstr(list->term), "$&division", "arguments must be numbers");
 
         if (divisor == 0.0)
             fail("$&division", "division by zero");
@@ -95,23 +110,16 @@ PRIM(division)
 }
 
 PRIM(modulo)
-{   char *endptr;
-    double dividend;
+{   double dividend;
     double divisor;
 
     if (list == NULL || list->next == NULL || list->next->next != NULL)
         fail("$&modulo", "usage: $&modulo dividend divisor");
 
-    dividend = strtod(getstr(list->term), &endptr);
-
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&modulo", "arguments must be numbers");
+    dividend = require_double(getstr(list->term), "$&modulo", "arguments must be numbers");
 
     list = list->next;
-    divisor = strtod(getstr(list->term), &endptr);
-
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&modulo", "arguments must be numbers");
+    divisor = require_double(getstr(list->term), "$&modulo", "arguments must be numbers");
 
     if (divisor == 0.0)
         fail("$&modulo", "division by zero");
@@ -120,23 +128,16 @@ PRIM(modulo)
 }
 
 PRIM(pow)
-{   char *endptr;
-    double base_value;
+{   double base_value;
     double exponent_value;
     double result;
 
     if (list == NULL || list->next == NULL || list->next->next != NULL)
         fail("$&pow", "usage: $&pow base exponent");
 
-    base_value = strtod(getstr(list->term), &endptr);
+    base_value = require_double(getstr(list->term), "$&pow", "base must be a number");
 
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&pow", "base must be a number");
-
-    exponent_value = strtod(getstr(list->next->term), &endptr);
-
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&pow", "exponent must be a number");
+    exponent_value = require_double(getstr(list->next->term), "$&pow", "exponent must be a number");
 
     if (base_value == 0.0 && exponent_value < 0.0)
         fail("$&pow", "zero cannot be raised to a negative power");
@@ -147,38 +148,27 @@ PRIM(pow)
 }
 
 PRIM(abs)
-{   char *endptr;
-    double input_value;
+{   double input_value;
  
     if (list == NULL || list->next != NULL)
         fail("$&abs", "usage: $&abs number");
     
-    input_value = strtod(getstr(list->term), &endptr);
-    
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&abs", "argument must be a number");
+    input_value = require_double(getstr(list->term), "$&abs", "argument must be a number");
     
     return mklist(mkstr(str("%g", fabs(input_value))), NULL);
 }
 
 PRIM(min)
-{   char *endptr;
-    double minimum_value;
- 
+{   double minimum_value;
+
     if (list == NULL)
         fail("$&min", "usage: $&min number [number ...]");
-    
-    minimum_value = strtod(getstr(list->term), &endptr);
-    
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&min", "arguments must be numbers");
- 
-    for (list = list->next; list != NULL; list = list->next)
-    {   double current_value = strtod(getstr(list->term), &endptr);
-     
-        if (endptr != NULL && *endptr != '\0')
-            fail("$&min", "arguments must be numbers");
-        
+
+    minimum_value = require_double(getstr(list->term), "$&min", "arguments must be numbers");
+
+    for (list = list->next; list != NULL; list = list->next) {
+        double current_value = require_double(getstr(list->term), "$&min", "arguments must be numbers");
+
         if (current_value < minimum_value)
             minimum_value = current_value;
     }
@@ -186,23 +176,16 @@ PRIM(min)
 }
 
 PRIM(max)
-{   char *endptr;
-    double maximum_value;
- 
+{   double maximum_value;
+
     if (list == NULL)
         fail("$&max", "usage: $&max number [number ...]");
-    
-    maximum_value = strtod(getstr(list->term), &endptr);
-    
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&max", "arguments must be numbers");
- 
-    for (list = list->next; list != NULL; list = list->next)
-    {   double current_value = strtod(getstr(list->term), &endptr);
-     
-        if (endptr != NULL && *endptr != '\0')
-            fail("$&max", "arguments must be numbers");
-        
+
+    maximum_value = require_double(getstr(list->term), "$&max", "arguments must be numbers");
+
+    for (list = list->next; list != NULL; list = list->next) {
+        double current_value = require_double(getstr(list->term), "$&max", "arguments must be numbers");
+
         if (current_value > maximum_value)
             maximum_value = current_value;
     }
@@ -218,24 +201,16 @@ PRIM(count)
  */
 
 PRIM(bitwiseshiftleft)
-{   char *endptr_for_value;
-    char *endptr_for_shift;
-    long  input_value;
+{   long  input_value;
     long  shift_amount;
     const int max_shift_bits = sizeof(long) * 8 - 1;
 
     if (list == NULL || list->next == NULL || list->next->next != NULL)
         fail("$&bitwiseshiftleft", "usage: $&bitwiseshiftleft value shift_amount");
 
-    input_value = strtol(getstr(list->term), &endptr_for_value, 0);
+    input_value = require_integer(getstr(list->term), "$&bitwiseshiftleft", "value argument");
 
-    if (endptr_for_value != NULL && *endptr_for_value != '\0')
-        fail("$&bitwiseshiftleft", "value argument must be an integer");
-
-    shift_amount = strtol(getstr(list->next->term), &endptr_for_shift, 0);
-
-    if (endptr_for_shift != NULL && *endptr_for_shift != '\0')
-        fail("$&bitwiseshiftleft", "shift_amount argument must be an integer");
+    shift_amount = require_integer(getstr(list->next->term), "$&bitwiseshiftleft", "shift_amount argument");
 
     if (shift_amount < 0)
         fail("$&bitwiseshiftleft", "shift_amount cannot be negative");
@@ -247,24 +222,16 @@ PRIM(bitwiseshiftleft)
 }
 
 PRIM(bitwiseshiftright)
-{   char *endptr_for_value;
-    char *endptr_for_shift;
-    long  input_value;
+{   long  input_value;
     long  shift_amount;
     const int max_shift_bits = sizeof(long) * 8 - 1;
 
     if (list == NULL || list->next == NULL || list->next->next != NULL)
         fail("$&bitwiseshiftright", "usage: $&bitwiseshiftright value shift_amount");
 
-    input_value = strtol(getstr(list->term), &endptr_for_value, 0);
+    input_value = require_integer(getstr(list->term), "$&bitwiseshiftright", "value argument");
 
-    if (endptr_for_value != NULL && *endptr_for_value != '\0')
-        fail("$&bitwiseshiftright", "value argument must be an integer");
-
-    shift_amount = strtol(getstr(list->next->term), &endptr_for_shift, 0);
-
-    if (endptr_for_shift != NULL && *endptr_for_shift != '\0')
-        fail("$&bitwiseshiftright", "shift_amount argument must be an integer");
+    shift_amount = require_integer(getstr(list->next->term), "$&bitwiseshiftright", "shift_amount argument");
 
     if (shift_amount < 0)
         fail("$&bitwiseshiftright", "shift_amount cannot be negative");
@@ -275,70 +242,51 @@ PRIM(bitwiseshiftright)
     return mklist(mkstr(str("%ld", input_value >> shift_amount)), NULL);
 }
 
-PRIM(and)
-{   char *endptr;
-    long  result;
+PRIM(bitwiseand)
+{   long  result;
  
     if (list == NULL)
-        fail("$&and", "usage: $&and number [number ...]");
+        fail("$&bitwiseand", "usage: $&bitwiseand number [number ...]");
     
-    result = strtol(getstr(list->term), &endptr, 0);
-    
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&and", "arguments must be integers");
+    result = require_integer(getstr(list->term), "$&bitwiseand", "each argument");
  
     for (list = list->next; list != NULL; list = list->next)
-    {   long operand = strtol(getstr(list->term), &endptr, 0);
-     
-        if (endptr != NULL && *endptr != '\0')
-            fail("$&and", "arguments must be integers");
-        
+    {   long operand = require_integer(getstr(list->term), "$&bitwiseand", "each argument");
+
         result &= operand;
     }
     return mklist(mkstr(str("%ld", result)), NULL);
 }
 
-PRIM(or)
-{   char *endptr;
-    long  result = 0;
+PRIM(bitwiseor)
+{   long  result = 0;
  
     for (List *lp = list; lp != NULL; lp = lp->next)
-    {   long operand = strtol(getstr(lp->term), &endptr, 0);
-     
-        if (endptr != NULL && *endptr != '\0')
-            fail("$&or", "arguments must be integers");
-        
+    {   long operand = require_integer(getstr(lp->term), "$&bitwiseor", "each argument");
+
         result |= operand;
     }
     return mklist(mkstr(str("%ld", result)), NULL);
 }
 
-PRIM(xor)
-{   char *endptr;
-    long  result = 0;
+PRIM(bitwisexor)
+{   long  result = 0;
  
     for (List *lp = list; lp != NULL; lp = lp->next)
-    {   long operand = strtol(getstr(lp->term), &endptr, 0);
-     
-        if (endptr != NULL && *endptr != '\0')
-            fail("$&xor", "arguments must be integers");
-        
+    {   long operand = require_integer(getstr(lp->term), "$&bitwisexor", "each argument");
+
         result ^= operand;
     }
     return mklist(mkstr(str("%ld", result)), NULL);
 }
 
-PRIM(not)
-{   char *endptr;
-    long  input_value;
+PRIM(bitwisenot)
+{   long  input_value;
  
     if (list == NULL || list->next != NULL)
-        fail("$&not", "usage: $&not number");
+        fail("$&bitwisenot", "usage: $&bitwisenot number");
     
-    input_value = strtol(getstr(list->term), &endptr, 0);
-    
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&not", "argument must be an integer");
+    input_value = require_integer(getstr(list->term), "$&bitwisenot", "argument");
     
     return mklist(mkstr(str("%ld", ~input_value)), NULL);
 }
@@ -348,111 +296,81 @@ PRIM(not)
  */
 
 PRIM(greater)
-{   char *endptr;
-    double first, second;
+{   double first, second;
 
     if (list == NULL || list->next == NULL || list->next->next != NULL)
         fail("$&greater", "usage: $&greater number1 number2");
 
-    first = strtod(getstr(list->term), &endptr);
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&greater", "arguments must be numbers");
+    first = require_double(getstr(list->term), "$&greater", "arguments must be numbers");
 
-    second = strtod(getstr(list->next->term), &endptr);
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&greater", "arguments must be numbers");
+    second = require_double(getstr(list->next->term), "$&greater", "arguments must be numbers");
 
     return first > second ? ltrue : lfalse;
 }
 
 PRIM(less)
-{   char *endptr;
-    double first, second;
+{   double first, second;
 
     if (list == NULL || list->next == NULL || list->next->next != NULL)
         fail("$&less", "usage: $&less number1 number2");
 
-    first = strtod(getstr(list->term), &endptr);
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&less", "arguments must be numbers");
+    first = require_double(getstr(list->term), "$&less", "arguments must be numbers");
 
-    second = strtod(getstr(list->next->term), &endptr);
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&less", "arguments must be numbers");
+    second = require_double(getstr(list->next->term), "$&less", "arguments must be numbers");
 
     return first < second ? ltrue : lfalse;
 }
 
 PRIM(greaterequal)
-{   char *endptr;
-    double first, second;
+{   double first, second;
 
     if (list == NULL || list->next == NULL || list->next->next != NULL)
         fail("$&greaterequal", "usage: $&greaterequal number1 number2");
 
-    first = strtod(getstr(list->term), &endptr);
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&greaterequal", "arguments must be numbers");
+    first = require_double(getstr(list->term), "$&greaterequal", "arguments must be numbers");
 
-    second = strtod(getstr(list->next->term), &endptr);
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&greaterequal", "arguments must be numbers");
+    second = require_double(getstr(list->next->term), "$&greaterequal", "arguments must be numbers");
 
     return first >= second ? ltrue : lfalse;
 }
 
 PRIM(lessequal)
-{   char *endptr;
-    double first, second;
+{   double first, second;
 
     if (list == NULL || list->next == NULL || list->next->next != NULL)
         fail("$&lessequal", "usage: $&lessequal number1 number2");
 
-    first = strtod(getstr(list->term), &endptr);
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&lessequal", "arguments must be numbers");
+    first = require_double(getstr(list->term), "$&lessequal", "arguments must be numbers");
 
-    second = strtod(getstr(list->next->term), &endptr);
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&lessequal", "arguments must be numbers");
+    second = require_double(getstr(list->next->term), "$&lessequal", "arguments must be numbers");
 
     return first <= second ? ltrue : lfalse;
 }
 
 PRIM(equal)
-{   char *endptr;
-    double first, second;
+{   double first, second;
     const double epsilon = 1e-15;
 
     if (list == NULL || list->next == NULL || list->next->next != NULL)
         fail("$&equal", "usage: $&equal number1 number2");
 
-    first = strtod(getstr(list->term), &endptr);
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&equal", "arguments must be numbers");
+    first = require_double(getstr(list->term), "$&equal", "arguments must be numbers");
 
-    second = strtod(getstr(list->next->term), &endptr);
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&equal", "arguments must be numbers");
+    second = require_double(getstr(list->next->term), "$&equal", "arguments must be numbers");
 
     return fabs(first - second) < epsilon ? ltrue : lfalse;
 }
 
 PRIM(notequal)
-{   char *endptr;
-    double first, second;
+{   double first, second;
     const double epsilon = 1e-15;
 
     if (list == NULL || list->next == NULL || list->next->next != NULL)
         fail("$&notequal", "usage: $&notequal number1 number2");
 
-    first = strtod(getstr(list->term), &endptr);
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&notequal", "arguments must be numbers");
+    first = require_double(getstr(list->term), "$&notequal", "arguments must be numbers");
 
-    second = strtod(getstr(list->next->term), &endptr);
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&notequal", "arguments must be numbers");
+    second = require_double(getstr(list->next->term), "$&notequal", "arguments must be numbers");
 
     return fabs(first - second) >= epsilon ? ltrue : lfalse;
 }
@@ -471,9 +389,7 @@ PRIM(toint)
     result = strtol(getstr(list->term), &endptr, 0);
     if (endptr != NULL && *endptr != '\0') {
         /* Try parsing as float first, then convert to int */
-        double d = strtod(getstr(list->term), &endptr);
-        if (endptr != NULL && *endptr != '\0')
-            fail("$&toint", "argument must be a number");
+        double d = require_double(getstr(list->term), "$&toint", "argument must be a number");
         result = (long)d;
     }
 
@@ -481,30 +397,23 @@ PRIM(toint)
 }
 
 PRIM(tofloat)
-{   char *endptr;
-    double result;
+{   double result;
 
     if (list == NULL || list->next != NULL)
         fail("$&tofloat", "usage: $&tofloat number");
 
-    result = strtod(getstr(list->term), &endptr);
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&tofloat", "argument must be a number");
+    result = require_double(getstr(list->term), "$&tofloat", "argument must be a number");
 
     return mklist(mkstr(str("%g", result)), NULL);
 }
 
 PRIM(isint)
-{   char *endptr;
-    long dummy;
+{   long value;
 
     if (list == NULL || list->next != NULL)
         fail("$&isint", "usage: $&isint value");
 
-    dummy = strtol(getstr(list->term), &endptr, 0);
-    (void)dummy; /* suppress unused variable warning */
-    
-    return (endptr != NULL && *endptr != '\0') ? lfalse : ltrue;
+    return try_parse_long(getstr(list->term), &value) ? ltrue : lfalse;
 }
 
 PRIM(isfloat)
@@ -515,11 +424,15 @@ PRIM(isfloat)
     if (list == NULL || list->next != NULL)
         fail("$&isfloat", "usage: $&isfloat value");
 
+    errno = 0;
     dummy = strtod(str_val, &endptr);
     (void)dummy; /* suppress unused variable warning */
-    
+
+    if (errno == ERANGE)
+        return lfalse;
+
     /* It's a float if it parses as a number AND contains a decimal point */
-    return (endptr != NULL && *endptr != '\0') ? lfalse : 
+    return (endptr != NULL && *endptr != '\0') ? lfalse :
            (strchr(str_val, '.') != NULL) ? ltrue : lfalse;
 }
 
@@ -528,14 +441,10 @@ PRIM(isfloat)
  */
 
 PRIM(intaddition)
-{   char *endptr;
-    long result = 0;
+{   long result = 0;
 
     for (List *lp = list; lp != NULL; lp = lp->next) {
-        long operand = strtol(getstr(lp->term), &endptr, 0);
-
-        if (endptr != NULL && *endptr != '\0')
-            fail("$&intaddition", "arguments must be integers");
+        long operand = require_integer(getstr(lp->term), "$&intaddition", "each argument");
 
         result += operand;
     }
@@ -543,21 +452,15 @@ PRIM(intaddition)
 }
 
 PRIM(intsubtraction)
-{   char *endptr;
-    long result;
+{   long result;
 
     if (list == NULL || list->next == NULL)
         fail("$&intsubtraction", "usage: $&intsubtraction number number [...]");
 
-    result = strtol(getstr(list->term), &endptr, 0);
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&intsubtraction", "arguments must be integers");
+    result = require_integer(getstr(list->term), "$&intsubtraction", "each argument");
 
     for (list = list->next; list != NULL; list = list->next) {
-        long operand = strtol(getstr(list->term), &endptr, 0);
-
-        if (endptr != NULL && *endptr != '\0')
-            fail("$&intsubtraction", "arguments must be integers");
+        long operand = require_integer(getstr(list->term), "$&intsubtraction", "each argument");
 
         result -= operand;
     }
@@ -565,17 +468,13 @@ PRIM(intsubtraction)
 }
 
 PRIM(intmultiplication)
-{   char *endptr;
-    long result = 1;
+{   long result = 1;
 
     if (list == NULL)
         fail("$&intmultiplication", "usage: $&intmultiplication number [...]");
 
     for (List *lp = list; lp != NULL; lp = lp->next) {
-        long operand = strtol(getstr(lp->term), &endptr, 0);
-
-        if (endptr != NULL && *endptr != '\0')
-            fail("$&intmultiplication", "arguments must be integers");
+        long operand = require_integer(getstr(lp->term), "$&intmultiplication", "each argument");
 
         result *= operand;
     }
@@ -583,21 +482,15 @@ PRIM(intmultiplication)
 }
 
 PRIM(intdivision)
-{   char *endptr;
-    long result;
+{   long result;
 
     if (list == NULL || list->next == NULL)
         fail("$&intdivision", "usage: $&intdivision dividend divisor [...]");
 
-    result = strtol(getstr(list->term), &endptr, 0);
-    if (endptr != NULL && *endptr != '\0')
-        fail("$&intdivision", "arguments must be integers");
+    result = require_integer(getstr(list->term), "$&intdivision", "each argument");
 
     for (list = list->next; list != NULL; list = list->next) {
-        long divisor = strtol(getstr(list->term), &endptr, 0);
-
-        if (endptr != NULL && *endptr != '\0')
-            fail("$&intdivision", "arguments must be integers");
+        long divisor = require_integer(getstr(list->term), "$&intdivision", "each argument");
 
         if (divisor == 0)
             fail("$&intdivision", "division by zero");
@@ -639,10 +532,10 @@ extern Dict *initprims_math(Dict *primdict)
     /* Bitwise operations */
     X(bitwiseshiftleft);
     X(bitwiseshiftright);
-    X(and);
-    X(or);
-    X(xor);
-    X(not);
+    X(bitwiseand);
+    X(bitwiseor);
+    X(bitwisexor);
+    X(bitwisenot);
     
     /* Comparison operations */
     X(greater);

--- a/print.c
+++ b/print.c
@@ -3,6 +3,8 @@
 #include "es.h"
 #include "print.h"
 
+#include <stdio.h>
+
 #define	MAXCONV 256
 
 /*
@@ -150,8 +152,20 @@ static Boolean oconv(Format *format) {
 }
 
 static Boolean xconv(Format *format) {
-	intconv(format, 16, 0, "0x");
-	return FALSE;
+        intconv(format, 16, 0, "0x");
+        return FALSE;
+}
+
+static Boolean gconv(Format *format) {
+        char buf[128];
+        double value = va_arg(format->args, double);
+        int len = snprintf(buf, sizeof buf, "%g", value);
+
+        if (len < 0)
+                return FALSE;
+
+        fmtappend(format, buf, (size_t)len);
+        return FALSE;
 }
 
 static Boolean pctconv(Format *format) {
@@ -180,10 +194,11 @@ static void inittab(void) {
 
 	fmttab['s'] = sconv;
 	fmttab['c'] = cconv;
-	fmttab['d'] = dconv;
-	fmttab['o'] = oconv;
-	fmttab['x'] = xconv;
-	fmttab['%'] = pctconv;
+        fmttab['d'] = dconv;
+        fmttab['o'] = oconv;
+        fmttab['x'] = xconv;
+        fmttab['g'] = gconv;
+        fmttab['%'] = pctconv;
 
 	fmttab['u'] = uconv;
 	fmttab['h'] = hconv;
@@ -237,8 +252,8 @@ extern void fmtcat(Format *format, const char *s) {
 extern int printfmt(Format *format, const char *fmt) {
 	unsigned char *s = (unsigned char *) fmt;
 
-	if (fmttab[0] == NULL)
-		inittab();
+        if (fmttab == NULL)
+                inittab();
 
 	for (;;) {
 		int c = *s++;

--- a/proc.c
+++ b/proc.c
@@ -2,6 +2,8 @@
 
 #include "es.h"
 
+#include <limits.h>
+
 Boolean hasforked = FALSE;
 
 typedef struct Proc Proc;
@@ -118,24 +120,30 @@ extern Noreturn esexit(int code) {
 
 /* reap -- mark a process as dead and return it */
 static Proc *reap(int pid) {
-	Proc *proc;
-	for (proc = proclist; proc != NULL; proc = proc->next)
-		if (proc->pid == pid)
-			break;
-	assert(proc != NULL);
+        Proc *proc;
+        for (proc = proclist; proc != NULL; proc = proc->next)
+                if (proc->pid == pid)
+                        break;
+        assert(proc != NULL);
 	if (proc->next != NULL)
 		proc->next->prev = proc->prev;
 	if (proc->prev != NULL)
 		proc->prev->next = proc->next;
 	else
 		proclist = proc->next;
-	return proc;
+        return proc;
+}
+
+static int compare_pid(const void *a, const void *b) {
+        int left = *(const int *) a;
+        int right = *(const int *) b;
+        return (left > right) - (left < right);
 }
 
 /* ewait -- wait for a specific process to die, or any process if pid == -1 */
 extern int ewait(int pidarg, Boolean interruptible) {
-	int deadpid, status;
-	Proc *proc;
+        int deadpid, status;
+        Proc *proc;
 	while ((deadpid = waitpid(pidarg, &status, 0)) == -1) {
 		if (errno == ECHILD && pidarg > 0)
 			fail("es:ewait", "wait: %d is not a child of this shell", pidarg);
@@ -157,32 +165,54 @@ extern int ewait(int pidarg, Boolean interruptible) {
 #include "prim.h"
 
 PRIM(apids) {
-	Proc *p;
-	Ref(List *, lp, NULL);
-	for (p = proclist; p != NULL; p = p->next)
-		if (p->background) {
-			Term *t = mkstr(str("%d", p->pid));
-			lp = mklist(t, lp);
-		}
-	/* TODO: sort the return value, but by number? */
-	RefReturn(lp);
+        Proc *p;
+        Ref(List *, lp, NULL);
+        size_t count = 0;
+
+        for (p = proclist; p != NULL; p = p->next)
+                if (p->background)
+                        count++;
+
+        if (count != 0) {
+                size_t i = 0;
+                int *pids = ealloc(count * sizeof (int));
+
+                for (p = proclist; p != NULL; p = p->next)
+                        if (p->background)
+                                pids[i++] = p->pid;
+
+                qsort(pids, count, sizeof (int), compare_pid);
+
+                for (i = count; i-- > 0; ) {
+                        Term *t = mkstr(str("%d", pids[i]));
+                        lp = mklist(t, lp);
+                }
+
+                efree(pids);
+        }
+        RefReturn(lp);
 }
 
 PRIM(wait) {
-	int pid;
-	if (list == NULL)
-		pid = -1;
-	else if (list->next == NULL) {
-		pid = atoi(getstr(list->term));
-		if (pid <= 0) {
-			fail("$&wait", "wait: %d: bad pid", pid);
-			NOTREACHED;
-		}
-	} else {
-		fail("$&wait", "usage: wait [pid]");
-		NOTREACHED;
-	}
-	return mklist(mkstr(mkstatus(ewait(pid, TRUE))), NULL);
+        int pid;
+        if (list == NULL)
+                pid = -1;
+        else if (list->next == NULL) {
+                char *strpid = getstr(list->term);
+                char *end;
+                long parsed = strtol(strpid, &end, 10);
+
+                if (*strpid == '\0' || *end != '\0' || parsed <= 0 || parsed > INT_MAX) {
+                        fail("$&wait", "wait: %s: bad pid", strpid);
+                        NOTREACHED;
+                }
+
+                pid = (int) parsed;
+        } else {
+                fail("$&wait", "usage: wait [pid]");
+                NOTREACHED;
+        }
+        return mklist(mkstr(mkstatus(ewait(pid, TRUE))), NULL);
 }
 
 extern Dict *initprims_proc(Dict *primdict) {

--- a/test/tests/math.es
+++ b/test/tests/math.es
@@ -31,3 +31,34 @@ test 'math logs' {
         }
 }
 
+test 'bitwise parsing rejects non-integers' {
+        let (exception = ()) {
+                catch @ e {exception = $e} {%bitwiseshiftleft '' 1 >[2] /dev/null}
+                assert {~ $exception *'value argument must be an integer: '*}
+        }
+
+        let (exception = ()) {
+                catch @ e {exception = $e} {%bitwiseand 1 not-a-number >[2] /dev/null}
+                assert {~ $exception *'each argument must be an integer: not-a-number'*}
+        }
+}
+
+test 'isint is strict about digits' {
+        assert {! {%isint ''}} 'empty strings are not integers'
+        assert {! {%isint 'abc'}} 'alphabetic strings are not integers'
+}
+
+test 'float parsing rejects overflow' {
+        let (exception = ()) {
+                catch @ e {exception = $e} {%addition 1e309 >[2] /dev/null}
+                assert {~ $exception *'arguments must be numbers'*} 'addition rejects overflow'
+        }
+
+        let (exception = ()) {
+                catch @ e {exception = $e} {%tofloat 1e309 >[2] /dev/null}
+                assert {~ $exception *'argument must be a number'*} 'tofloat rejects overflow'
+        }
+
+        assert {! {%isfloat 1e309}} 'overflowing numbers are not floats'
+}
+

--- a/test/tests/option.es
+++ b/test/tests/option.es
@@ -26,7 +26,7 @@ test 'es -e' {
 			'let (x = false) true'			true
 			'local (x = false) true'		true
 		)) {
-			cat > $temp << EOF
+			cat > $temp <--< EOF
 echo -n one
 $command
 echo two

--- a/test/tests/subscript.es
+++ b/test/tests/subscript.es
@@ -1,0 +1,25 @@
+# tests/subscript.es -- validate variable subscript parsing
+
+test 'rejects trailing junk in single subscript' {
+        foo = (a b c)
+        let (exception = ()) {
+                catch @ e {exception = $e} {echo $foo(2abc)}
+                assert {~ $exception *'bad subscript: 2abc'*}
+        }
+}
+
+test 'rejects trailing junk in range subscript' {
+        foo = (a b c)
+        let (exception = ()) {
+                catch @ e {exception = $e} {echo $foo(1...3abc)}
+                assert {~ $exception *'bad subscript: 1...3abc'*}
+        }
+}
+
+test 'rejects descending range subscript' {
+        foo = (a b c)
+        let (exception = ()) {
+                catch @ e {exception = $e} {echo $foo(3...2)}
+                assert {~ $exception *'bad subscript: 3...2'*}
+        }
+}

--- a/test/tests/syntax.es
+++ b/test/tests/syntax.es
@@ -65,16 +65,15 @@ test 'readfrom/writeto sugar' {
 }
 
 test 'heredoc sugar' {
-	let (
-		# NOTE: is it a bug that this only works with the closing newline?
-		have = 'cmd << tag
+        let (
+                # heredoc sugar should not require a trailing newline after the eof marker
+                have = 'cmd <--< tag
 input
-tag
-'
-		want = '%here 0 ''input''^\n {cmd}'
-	) {
-		assert {~ `` \n {eval echo '{'$have'}'} '{'$want'}'}
-	}
+tag'
+                want = '%here 0 ''input''^\n {cmd}'
+        ) {
+                assert {~ `` \n {eval echo '{'$have'}'} '{'$want'}'}
+        }
 }
 
 test 'match sugar' {

--- a/test/tests/trip.es
+++ b/test/tests/trip.es
@@ -199,12 +199,12 @@ test 'heredocs and herestrings' {
 this is an heredoc
 '
 		) {
-			assert {~ `` '' {<<[5] EOF cat <[0=5]} $result} 'unquoted heredoc'
+			assert {~ `` '' {<--<[5] EOF cat <[0=5]} $result} 'unquoted heredoc'
 $abc heredoc$x
 $abc^n $x^here$x^doc
 EOF
 		}
-		assert {~ `` \n cat '	'} 'quoted heredoc' << ' '
+		assert {~ `` \n cat '	'} 'quoted heredoc' <--< ' '
 	
  
 		<<<[9] `` '' {cat $bigfile} \
@@ -215,18 +215,20 @@ EOF
 		rm -f $bigfile
 	}
 
-	assert {~ `{cat<<eof
+        assert {~ `{cat<--<eof
 $$
 eof
-	} '$'} 'quoting ''$'' in heredoc'
+        } '$'} 'quoting ''$'' in heredoc'
 
-	assert {~ `` \n {$es -c 'cat<<eof' >[2=1]} *'pending'*} 'incomplete heredoc 1'
-	assert {~ `` \n {$es -c 'cat<<eof'\n >[2=1]} *'incomplete'*} 'incomplete heredoc 2'
-	assert {~ `` \n {$es -c 'cat<<eof'\n\$ >[2=1]} *'incomplete'*} 'incomplete heredoc 3'
+        assert {~ `` \n {$es -c 'cat<<legacy\nlegacy' >[2=1]} *'here documents now use <--<'*} 'legacy heredoc operator is rejected'
 
-	assert {~ `` \n {$es -c 'cat<<()' >[2=1]} *'not a single literal word'*} 'bad heredoc marker 1'
-	assert {~ `` \n {$es -c 'cat<<(eof eof)' >[2=1]} *'not a single literal word'*} 'bad heredoc marker 2'
-	assert {~ `` \n {$es -c 'cat<<'''\n''''\n >[2=1]} *'contains a newline'*} 'bad heredoc marker 3'
+        assert {~ `` \n {$es -c 'cat<--<eof' >[2=1]} *'pending'*} 'incomplete heredoc 1'
+        assert {~ `` \n {$es -c 'cat<--<eof'\n >[2=1]} *'incomplete'*} 'incomplete heredoc 2'
+        assert {~ `` \n {$es -c 'cat<--<eof'\n\$ >[2=1]} *'incomplete'*} 'incomplete heredoc 3'
+
+	assert {~ `` \n {$es -c 'cat<--<()' >[2=1]} *'not a single literal word'*} 'bad heredoc marker 1'
+	assert {~ `` \n {$es -c 'cat<--<(eof eof)' >[2=1]} *'not a single literal word'*} 'bad heredoc marker 2'
+	assert {~ `` \n {$es -c 'cat<--<'''\n''''\n >[2=1]} *'contains a newline'*} 'bad heredoc marker 3'
 }
 
 test 'tilde matching' {

--- a/test/tests/wait.es
+++ b/test/tests/wait.es
@@ -31,10 +31,17 @@ test 'wait is precise' {
 }
 
 test 'setpgid' {
-	let (pid = <={$&background {./testrun s}}) {
-		assert {ps -o pid | grep $pid > /dev/null} 'background process appears in ps'
-		kill $pid
-		wait $pid >[2] /dev/null
-		assert {!{ps -o pid | grep $pid}}
-	}
+        let (pid = <={$&background {./testrun s}}) {
+                assert {ps -o pid | grep $pid > /dev/null} 'background process appears in ps'
+                kill $pid
+                wait $pid >[2] /dev/null
+                assert {!{ps -o pid | grep $pid}}
+        }
+}
+
+test 'rejects non-numeric pid' {
+        let (exception = ()) {
+                catch @ e {exception = $e} {wait pid42 >[2] /dev/null}
+                assert {~ $exception *'wait: pid42: bad pid'*}
+        }
 }

--- a/token.c
+++ b/token.c
@@ -364,40 +364,42 @@ top:	while ((c = GETC()) == ' ' || c == '	') {
 	{
 		char *cmd;
 		int fd[2];
-        case '<':
-                fd[0] = 0;
-                if ((c = GETC()) == '>')
+	case '<':
+		fd[0] = 0;
+		if ((c = GETC()) == '>')
 			if ((c = GETC()) == '>') {
 				c = GETC();
 				cmd = "%open-append";
 			} else
 				cmd = "%open-write";
-		else if (c == '<')
-			if ((c = GETC()) == '<') {
+		else if (c == '<') {
+			int next = GETC();
+			if (next == '<') {
 				c = GETC();
 				cmd = "%here";
-			} else
-				cmd = "%heredoc";
-		else if (c == '=') {
+			} else {
+				scanerror(next, "here documents now use <--<");
+				return ERROR;
+			}
+		} else if (c == '-') {
+			int dash = GETC();
+			if (dash == '-') {
+				int lt = GETC();
+				if (lt == '<') {
+					c = GETC();
+					cmd = "%heredoc";
+					goto redirection;
+				}
+				UNGETC(lt);
+			}
+			UNGETC(dash);
+			cmd = "%open";
+		} else if (c == '=') {
 			w = NW;
 			return CALL;
 		} else
 			cmd = "%open";
 		goto redirection;
-        case '>':
-                fd[0] = 1;
-                if ((c = GETC()) == '>')
-                        if ((c = GETC()) == '<') {
-                                c = GETC();
-                                cmd = "%open-append";
-                        } else
-                                cmd = "%append";
-                else if (c == '<') {
-                        c = GETC();
-                        cmd = "%open-create";
-                } else
-                        cmd = "%create";
-                goto redirection;
 	redirection:
 		w = NW;
 		if (!getfds(fd, c, fd[0], DEFAULT))


### PR DESCRIPTION
## Summary
- update heredoc parsing to recognize the `<--<` operator, emitting an explanatory error for legacy `<<`
- refresh documentation, examples, and syntax expectations to use the new heredoc spelling
- add regression coverage for the renamed heredoc operator and the legacy rejection path

## Testing
- ./build.sh --output-dir bin

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693babbdf824832cabe4b30ccc74dbc6)